### PR TITLE
add Enum instance for Char, fix all versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 
     instance enumBoolean :: Enum Boolean
 
+    instance enumChar :: Enum Char
+
     instance enumMaybe :: (Enum a) => Enum (Maybe a)
 
     instance enumTuple :: (Enum a, Enum b) => Enum (Tuple a b)

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-maybe":  "*",
-    "purescript-tuples": "*"
+    "purescript-maybe":   "~0.2.1",
+    "purescript-tuples":  "~0.2.1",
+    "purescript-strings": "~0.3.2"
   }
 }

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -13,6 +13,7 @@ module Data.Enum
 
   import Data.Maybe
   import Data.Tuple
+  import Data.Char
   import Data.Maybe.Unsafe
 
   newtype Cardinality a = Cardinality Number 
@@ -54,6 +55,17 @@ module Data.Enum
 
   maybeCardinality :: forall a. (Enum a) => Cardinality a -> Cardinality (Maybe a)
   maybeCardinality c = Cardinality $ 1 + (runCardinality c)
+
+  instance enumChar :: Enum Char where
+    cardinality = Cardinality (65535 + 1)
+
+    firstEnum = fromCharCode 0
+
+    lastEnum = fromCharCode 65535
+
+    succ c = if c == lastEnum then Nothing else Just $ (fromCharCode <<< ((+) 1) <<< toCharCode) c
+
+    pred c = if c == firstEnum then Nothing else Just $ (fromCharCode <<< ((+) (-1)) <<< toCharCode) c
 
   instance enumMaybe :: (Enum a) => Enum (Maybe a) where
     cardinality = maybeCardinality cardinality


### PR DESCRIPTION
This is fully backward compatible, albeit with one caveat: it adds a dependency on the latest version of purescript-strings, so could potentially introduce a conflict if released under a patch fix update (albeit, only in the case a user of the library is not compatible with the latest purescript-strings and has opted not to fix patch version for their dependency on purescript-enums).

The current version is `0.2.1`, so this could be `0.2.2` under a patch fix update, or `0.3.0` otherwise.
