### PR TITLE
Separate Enum/Finite classes, fix bugs in the Maybe instance, and add Unit instance

### DIFF
--- a/docs/Data/Enum.md
+++ b/docs/Data/Enum.md
@@ -16,8 +16,7 @@ runCardinality :: forall a. Cardinality a -> Int
 #### `Enum`
 
 ``` purescript
-class (Bounded a) <= Enum a where
-  cardinality :: Cardinality a
+class Enum a where
   succ :: a -> Maybe a
   pred :: a -> Maybe a
   toEnum :: Int -> Maybe a
@@ -26,13 +25,11 @@ class (Bounded a) <= Enum a where
 
 Type class for enumerations. This should not be considered a part of a
 numeric hierarchy, ala Haskell. Rather, this is a type class for small,
-ordered sum types with statically-determined cardinality and the ability
-to easily compute successor and predecessor elements. e.g. `DayOfWeek`, etc.
+ordered sum types with the ability to easily compute successor and
+predecessor elements. e.g. `DayOfWeek`, etc.
 
 Laws:
 
-- ```succ bottom >>= succ >>= succ ... succ [cardinality - 1 times] == top```
-- ```pred top    >>= pred >>= pred ... pred [cardinality - 1 times] == bottom```
 - ```e1 `compare` e2 == fromEnum e1 `compare` fromEnum e2```
 - ```forall a > bottom: pred a >>= succ == Just a```
 - ```forall a < top:  succ a >>= pred == Just a```
@@ -44,11 +41,12 @@ Laws:
 
 ##### Instances
 ``` purescript
+instance enumUnit :: Enum Unit
 instance enumChar :: Enum Char
-instance enumMaybe :: (Enum a) => Enum (Maybe a)
+instance enumMaybe :: (Finite a) => Enum (Maybe a)
 instance enumBoolean :: Enum Boolean
-instance enumTuple :: (Enum a, Enum b) => Enum (Tuple a b)
-instance enumEither :: (Enum a, Enum b) => Enum (Either a b)
+instance enumTuple :: (Finite a, Finite b) => Enum (Tuple a b)
+instance enumEither :: (Finite a, Finite b) => Enum (Either a b)
 ```
 
 #### `defaultSucc`
@@ -122,5 +120,32 @@ intStepFromTo :: Int -> Int -> Int -> Array Int
 ```
 
 Property: ```forall e in intStepFromTo step a b: a <= e <= b```
+
+#### `Finite`
+
+``` purescript
+class (Bounded a, Enum a) <= Finite a where
+  cardinality :: Cardinality a
+```
+
+Type class for finite enumerations. This should not be considered a part of
+a numeric hierarchy, ala Haskell. Rather, this is a type class for small,
+ordered sum types with statically-determined cardinality and the ability
+to easily compute successor and predecessor elements. e.g. `DayOfWeek`, etc.
+
+Laws:
+
+- ```succ bottom >>= succ >>= succ ... succ [cardinality - 1 times] == top```
+- ```pred top    >>= pred >>= pred ... pred [cardinality - 1 times] == bottom```
+
+##### Instances
+``` purescript
+instance finiteUnit :: Finite Unit
+instance finiteChar :: Finite Char
+instance finiteMaybe :: (Finite a) => Finite (Maybe a)
+instance finiteBoolean :: Finite Boolean
+instance finiteTuple :: (Finite a, Finite b) => Finite (Tuple a b)
+instance finiteEither :: (Finite a, Finite b) => Finite (Either a b)
+```
 
 

--- a/docs/Data/Enum.md
+++ b/docs/Data/Enum.md
@@ -31,13 +31,9 @@ predecessor elements. e.g. `DayOfWeek`, etc.
 Laws:
 
 - ```e1 `compare` e2 == fromEnum e1 `compare` fromEnum e2```
-- ```forall a > bottom: pred a >>= succ == Just a```
-- ```forall a < top:  succ a >>= pred == Just a```
 - ```pred >=> succ >=> pred = pred```
 - ```succ >=> pred >=> succ = succ```
 - ```toEnum (fromEnum a) = Just a```
-- ```forall a > bottom: fromEnum <$> pred a = Just (fromEnum a - 1)```
-- ```forall a < top:  fromEnum <$> succ a = Just (fromEnum a + 1)```
 
 ##### Instances
 ``` purescript
@@ -137,6 +133,10 @@ Laws:
 
 - ```succ bottom >>= succ >>= succ ... succ [cardinality - 1 times] == top```
 - ```pred top    >>= pred >>= pred ... pred [cardinality - 1 times] == bottom```
+- ```forall a > bottom: pred a >>= succ == Just a```
+- ```forall a < top:  succ a >>= pred == Just a```
+- ```forall a > bottom: fromEnum <$> pred a = Just (fromEnum a - 1)```
+- ```forall a < top:  fromEnum <$> succ a = Just (fromEnum a + 1)```
 
 ##### Instances
 ``` purescript

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -152,9 +152,7 @@ instance enumMaybe :: (Finite a) => Enum (Maybe a) where
   succ Nothing = Just $ bottom
   succ (Just a) = Just <$> succ a
   pred Nothing = Nothing
-  pred (Just a) = Just $ case pred a of
-    Nothing -> Nothing
-    m@(Just _) -> m
+  pred (Just a) = Just $ pred a
   toEnum = maybeToEnum cardinality
   fromEnum Nothing = zero
   fromEnum (Just e) = fromEnum e + one

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -107,6 +107,13 @@ class (Bounded a, Enum a) <= BoundedEnum a where
   toEnum :: Int -> Maybe a
   fromEnum :: a -> Int
 
+-- | Runs in `O(n)` where `n` is `fromEnum top`
+-- |
+-- | ```defaultCardinality = cardinality```
+defaultCardinality :: forall a. (Bounded a, Enum a) => Cardinality a
+defaultCardinality = Cardinality $ defaultCardinality' one (bottom :: a) where
+  defaultCardinality' i = maybe i (defaultCardinality' $ i + one) <<< succ
+
   -- | Runs in `O(n)` where `n` is `fromEnum a`
   -- |
   -- | ```defaultToEnum succ bottom = toEnum```

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -149,7 +149,7 @@ instance finiteChar :: Finite Char where
 
 -- TODO JB Finite is too restrictive on a, all we need is bottom
 instance enumMaybe :: (Finite a) => Enum (Maybe a) where
-  succ Nothing = Just $ bottom
+  succ Nothing = Just $ Just bottom
   succ (Just a) = Just <$> succ a
   pred Nothing = Nothing
   pred (Just a) = Just $ pred a

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -17,6 +17,8 @@ module Data.Enum
   , intStepFromTo
   , enumFromTo
   , enumFromThenTo
+  , upFrom
+  , downFrom
   ) where
 
 import Prelude
@@ -85,6 +87,14 @@ intStepFromTo step from to =
             then Just $ Tuple e (e + step)  -- Output the value e, set the next state to (e + step)
             else Nothing                    -- End of the collection.
           ) from
+
+diag a = Tuple a a
+
+upFrom :: forall a u. (Enum a, Unfoldable u) => a -> u a
+upFrom = unfoldr (map diag <<< succ)
+
+downFrom :: forall a u. (Enum a, Unfoldable u) => a -> u a
+downFrom = unfoldr (map diag <<< pred)
 
 -- | Type class for finite enumerations. This should not be considered a part of
 -- | a numeric hierarchy, ala Haskell. Rather, this is a type class for small,

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -202,7 +202,7 @@ booleanPred _     = Nothing
 
 instance enumTuple :: (Enum a, BoundedEnum b) => Enum (Tuple a b) where
   succ (Tuple a b) = maybe (flip Tuple bottom <$> succ a) (Just <<< Tuple a) (succ b)
-  pred (Tuple a b) = maybe (flip Tuple bottom <$> pred a) (Just <<< Tuple a) (pred b)
+  pred (Tuple a b) = maybe (flip Tuple top <$> pred a) (Just <<< Tuple a) (pred b)
 
 instance boundedEnumTuple :: (BoundedEnum a, BoundedEnum b) => BoundedEnum (Tuple a b) where
   cardinality = tupleCardinality cardinality cardinality

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -120,6 +120,16 @@ class (Bounded a, Enum a) <= Finite a where
 
 -- | ## Instances
 
+instance enumUnit :: Enum Unit where
+  succ = const Nothing
+  pred = const Nothing
+  toEnum 0 = Just unit
+  toEnum _ = Nothing
+  fromEnum = const 0
+
+instance finiteUnit :: Finite Unit where
+  cardinality = Cardinality 1
+
 instance enumChar :: Enum Char where
   succ = defaultSucc charToEnum charFromEnum
   pred = defaultPred charToEnum charFromEnum

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -13,8 +13,6 @@ module Data.Enum
   , defaultCardinality
   , defaultToEnum
   , defaultFromEnum
-  , intFromTo
-  , intStepFromTo
   , enumFromTo
   , enumFromThenTo
   , upFrom
@@ -59,11 +57,9 @@ defaultPred toEnum' fromEnum' a = toEnum' (fromEnum' a - one)
 -- | Property: ```fromEnum a = a', fromEnum b = b' => forall e', a' <= e' <= b': Exists e: toEnum e' = Just e```
 -- |
 -- | Following from the propery of `intFromTo`, we are sure all elements in `intFromTo (fromEnum a) (fromEnum b)` are `Just`s.
--- TODO this shouldn't require BoundedEnum, just Enum
-enumFromTo :: forall a. (BoundedEnum a) => a -> a -> Array a
-enumFromTo a b = (toEnum >>> fromJust) <$> intFromTo a' b'
-  where a' = fromEnum a
-        b' = fromEnum b
+-- TODO need to update the doc comment above
+enumFromTo :: forall a u. (Enum a, Unfoldable u) => a -> a -> u a
+enumFromTo from to = unfoldr (\x -> succ x >>= \x' -> if x <= to then pure $ Tuple x x' else Nothing) from
 
 -- | `[a,b..c]`
 -- |
@@ -74,10 +70,6 @@ enumFromThenTo a b c = (toEnum >>> fromJust) <$> intStepFromTo (b' - a') a' c'
   where a' = fromEnum a
         b' = fromEnum b
         c' = fromEnum c
-
--- | Property: ```forall e in intFromTo a b: a <= e <= b```
-intFromTo :: Int -> Int -> Array Int
-intFromTo = intStepFromTo one
 
 -- | Property: ```forall e in intStepFromTo step a b: a <= e <= b```
 intStepFromTo :: Int -> Int -> Int -> Array Int

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -238,7 +238,6 @@ eitherToEnum carda cardb n =
            then Right <$> toEnum (n - runCardinality carda)
            else Nothing
 
--- TODO this shouldn't require BoundedEnum
 eitherFromEnum :: forall a b. (BoundedEnum a, BoundedEnum b) => Cardinality a -> (Either a b -> Int)
 eitherFromEnum carda (Left a) = fromEnum a
 eitherFromEnum carda (Right b) = fromEnum b + runCardinality carda

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -42,7 +42,7 @@ runCardinality (Cardinality a) = a
 -- | - ```pred >=> succ >=> pred = pred```
 -- | - ```succ >=> pred >=> succ = succ```
 
-class Enum a where
+class (Ord a) <= Enum a where
   succ :: a -> Maybe a
   pred :: a -> Maybe a
 

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -200,7 +200,7 @@ booleanPred :: Boolean -> Maybe Boolean
 booleanPred true  = Just false
 booleanPred _     = Nothing
 
-instance enumTuple :: (BoundedEnum a, BoundedEnum b) => Enum (Tuple a b) where
+instance enumTuple :: (Enum a, BoundedEnum b) => Enum (Tuple a b) where
   succ (Tuple a b) = maybe (flip Tuple bottom <$> succ a) (Just <<< Tuple a) (succ b)
   pred (Tuple a b) = maybe (flip Tuple bottom <$> pred a) (Just <<< Tuple a) (pred b)
 
@@ -210,11 +210,9 @@ instance boundedEnumTuple :: (BoundedEnum a, BoundedEnum b) => BoundedEnum (Tupl
   fromEnum = tupleFromEnum cardinality
 
 -- | All of these are as a workaround for `ScopedTypeVariables`. (not yet supported in Purescript)
--- TODO we shouldn't need BoundedEnum on a
 tupleToEnum :: forall a b. (BoundedEnum a, BoundedEnum b) => Cardinality b -> Int -> Maybe (Tuple a b)
 tupleToEnum cardb n = Tuple <$> (toEnum (n / (runCardinality cardb))) <*> (toEnum (n `mod` (runCardinality cardb)))
 
--- TODO we shouldn't need BoundedEnum on a
 tupleFromEnum :: forall a b. (BoundedEnum a, BoundedEnum b) => Cardinality b -> Tuple a b -> Int
 tupleFromEnum cardb (Tuple a b) = (fromEnum a) * runCardinality cardb + fromEnum b
 

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -152,7 +152,9 @@ instance enumMaybe :: (Finite a) => Enum (Maybe a) where
   succ Nothing = Just $ bottom
   succ (Just a) = Just <$> succ a
   pred Nothing = Nothing
-  pred (Just a) = Just <$> pred a -- TODO JB this doesn't seem right, I think we skip over "Just Nothing"
+  pred (Just a) = Just $ case pred a of
+    Nothing -> Nothing
+    m@(Just _) -> m
   toEnum = maybeToEnum cardinality
   fromEnum Nothing = zero
   fromEnum (Just e) = fromEnum e + one

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -39,13 +39,9 @@ runCardinality (Cardinality a) = a
 -- | Laws:
 -- |
 -- | - ```e1 `compare` e2 == fromEnum e1 `compare` fromEnum e2```
--- | - ```forall a > bottom: pred a >>= succ == Just a```
--- | - ```forall a < top:  succ a >>= pred == Just a```
 -- | - ```pred >=> succ >=> pred = pred```
 -- | - ```succ >=> pred >=> succ = succ```
 -- | - ```toEnum (fromEnum a) = Just a```
--- | - ```forall a > bottom: fromEnum <$> pred a = Just (fromEnum a - 1)```
--- | - ```forall a < top:  fromEnum <$> succ a = Just (fromEnum a + 1)```
 
 class Enum a where
   succ :: a -> Maybe a
@@ -114,6 +110,10 @@ intStepFromTo step from to =
 -- |
 -- | - ```succ bottom >>= succ >>= succ ... succ [cardinality - 1 times] == top```
 -- | - ```pred top    >>= pred >>= pred ... pred [cardinality - 1 times] == bottom```
+-- | - ```forall a > bottom: pred a >>= succ == Just a```
+-- | - ```forall a < top:  succ a >>= pred == Just a```
+-- | - ```forall a > bottom: fromEnum <$> pred a = Just (fromEnum a - 1)```
+-- | - ```forall a < top:  fromEnum <$> succ a = Just (fromEnum a + 1)```
 
 class (Bounded a, Enum a) <= Finite a where
   cardinality :: Cardinality a

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -1,5 +1,6 @@
 module Data.Enum
   ( Enum
+  , Finite
   , Cardinality(..)
   , cardinality
   , fromEnum
@@ -32,13 +33,11 @@ runCardinality (Cardinality a) = a
 
 -- | Type class for enumerations. This should not be considered a part of a
 -- | numeric hierarchy, ala Haskell. Rather, this is a type class for small,
--- | ordered sum types with statically-determined cardinality and the ability
--- | to easily compute successor and predecessor elements. e.g. `DayOfWeek`, etc.
+-- | ordered sum types with the ability to easily compute successor and
+-- | predecessor elements. e.g. `DayOfWeek`, etc.
 -- |
 -- | Laws:
 -- |
--- | - ```succ bottom >>= succ >>= succ ... succ [cardinality - 1 times] == top```
--- | - ```pred top    >>= pred >>= pred ... pred [cardinality - 1 times] == bottom```
 -- | - ```e1 `compare` e2 == fromEnum e1 `compare` fromEnum e2```
 -- | - ```forall a > bottom: pred a >>= succ == Just a```
 -- | - ```forall a < top:  succ a >>= pred == Just a```
@@ -48,9 +47,7 @@ runCardinality (Cardinality a) = a
 -- | - ```forall a > bottom: fromEnum <$> pred a = Just (fromEnum a - 1)```
 -- | - ```forall a < top:  fromEnum <$> succ a = Just (fromEnum a + 1)```
 
-
-class (Bounded a) <= Enum a where
-  cardinality :: Cardinality a
+class Enum a where
   succ :: a -> Maybe a
   pred :: a -> Maybe a
   toEnum :: Int -> Maybe a
@@ -108,10 +105,22 @@ intStepFromTo step from to =
             else Nothing                    -- End of the collection.
           ) from
 
+-- | Type class for finite enumerations. This should not be considered a part of
+-- | a numeric hierarchy, ala Haskell. Rather, this is a type class for small,
+-- | ordered sum types with statically-determined cardinality and the ability
+-- | to easily compute successor and predecessor elements. e.g. `DayOfWeek`, etc.
+-- |
+-- | Laws:
+-- |
+-- | - ```succ bottom >>= succ >>= succ ... succ [cardinality - 1 times] == top```
+-- | - ```pred top    >>= pred >>= pred ... pred [cardinality - 1 times] == bottom```
+
+class (Bounded a, Enum a) <= Finite a where
+  cardinality :: Cardinality a
+
 -- | ## Instances
 
 instance enumChar :: Enum Char where
-  cardinality = Cardinality 65536
   succ = defaultSucc charToEnum charFromEnum
   pred = defaultPred charToEnum charFromEnum
   toEnum = charToEnum
@@ -125,32 +134,40 @@ charToEnum _ = Nothing
 charFromEnum :: Char -> Int
 charFromEnum = toCharCode
 
-instance enumMaybe :: (Enum a) => Enum (Maybe a) where
-  cardinality = maybeCardinality cardinality
+instance finiteChar :: Finite Char where
+  cardinality = Cardinality 65536
+
+-- TODO JB Finite is too restrictive on a, all we need is bottom
+instance enumMaybe :: (Finite a) => Enum (Maybe a) where
   succ Nothing = Just $ bottom
   succ (Just a) = Just <$> succ a
   pred Nothing = Nothing
-  pred (Just a) = Just <$> pred a
+  pred (Just a) = Just <$> pred a -- TODO JB this doesn't seem right, I think we skip over "Just Nothing"
   toEnum = maybeToEnum cardinality
   fromEnum Nothing = zero
   fromEnum (Just e) = fromEnum e + one
 
-maybeToEnum :: forall a. (Enum a) => Cardinality a -> Int -> Maybe (Maybe a)
+instance finiteMaybe :: (Finite a) => Finite (Maybe a) where
+  cardinality = maybeCardinality cardinality
+
+maybeToEnum :: forall a. (Finite a) => Cardinality a -> Int -> Maybe (Maybe a)
 maybeToEnum carda n | n <= runCardinality (maybeCardinality carda) =
   if n == zero
   then Just $ Nothing
   else Just $ toEnum (n - one)
 maybeToEnum _    _ = Nothing
 
-maybeCardinality :: forall a. (Enum a) => Cardinality a -> Cardinality (Maybe a)
+maybeCardinality :: forall a. (Finite a) => Cardinality a -> Cardinality (Maybe a)
 maybeCardinality c = Cardinality $ one + (runCardinality c)
 
 instance enumBoolean :: Enum Boolean where
-  cardinality = Cardinality 2
   succ = booleanSucc
   pred = booleanPred
   toEnum = defaultToEnum booleanSucc bottom
   fromEnum = defaultFromEnum booleanPred
+
+instance finiteBoolean :: Finite Boolean where
+  cardinality = Cardinality 2
 
 booleanSucc :: Boolean -> Maybe Boolean
 booleanSucc false = Just true
@@ -160,25 +177,27 @@ booleanPred :: Boolean -> Maybe Boolean
 booleanPred true  = Just false
 booleanPred _     = Nothing
 
-instance enumTuple :: (Enum a, Enum b) => Enum (Tuple a b) where
-  cardinality = tupleCardinality cardinality cardinality
+instance enumTuple :: (Finite a, Finite b) => Enum (Tuple a b) where
   succ (Tuple a b) = maybe (flip Tuple bottom <$> succ a) (Just <<< Tuple a) (succ b)
   pred (Tuple a b) = maybe (flip Tuple bottom <$> pred a) (Just <<< Tuple a) (pred b)
   toEnum = tupleToEnum cardinality
   fromEnum = tupleFromEnum cardinality
 
+instance finiteTuple :: (Finite a, Finite b) => Finite (Tuple a b) where
+  cardinality = tupleCardinality cardinality cardinality
+
 -- | All of these are as a workaround for `ScopedTypeVariables`. (not yet supported in Purescript)
-tupleToEnum :: forall a b. (Enum a, Enum b) => Cardinality b -> Int -> Maybe (Tuple a b)
+tupleToEnum :: forall a b. (Enum a, Finite b) => Cardinality b -> Int -> Maybe (Tuple a b)
 tupleToEnum cardb n = Tuple <$> (toEnum (n / (runCardinality cardb))) <*> (toEnum (n `mod` (runCardinality cardb)))
 
-tupleFromEnum :: forall a b. (Enum a, Enum b) => Cardinality b -> Tuple a b -> Int
+tupleFromEnum :: forall a b. (Enum a, Finite b) => Cardinality b -> Tuple a b -> Int
 tupleFromEnum cardb (Tuple a b) = (fromEnum a) * runCardinality cardb + fromEnum b
 
 tupleCardinality :: forall a b. (Enum a, Enum b) => Cardinality a -> Cardinality b -> Cardinality (Tuple a b)
 tupleCardinality l r = Cardinality $ (runCardinality l) * (runCardinality r)
 
-instance enumEither :: (Enum a, Enum b) => Enum (Either a b) where
-  cardinality = eitherCardinality cardinality cardinality
+-- TODO JB why do both a and b have to be finite?
+instance enumEither :: (Finite a, Finite b) => Enum (Either a b) where
   succ (Left a) = maybe (Just $ Right bottom) (Just <<< Left) (succ a)
   succ (Right b) = maybe (Nothing) (Just <<< Right) (succ b)
   pred (Left a) = maybe (Nothing) (Just <<< Left) (pred a)
@@ -186,7 +205,10 @@ instance enumEither :: (Enum a, Enum b) => Enum (Either a b) where
   toEnum = eitherToEnum cardinality cardinality
   fromEnum = eitherFromEnum cardinality
 
-eitherToEnum :: forall a b. (Enum a, Enum b) => Cardinality a -> Cardinality b -> Int -> Maybe (Either a b)
+instance finiteEither :: (Finite a, Finite b) => Finite (Either a b) where
+  cardinality = eitherCardinality cardinality cardinality
+
+eitherToEnum :: forall a b. (Finite a, Finite b) => Cardinality a -> Cardinality b -> Int -> Maybe (Either a b)
 eitherToEnum carda cardb n =
       if n >= zero && n < runCardinality carda
       then Left <$> toEnum n
@@ -198,5 +220,5 @@ eitherFromEnum :: forall a b. (Enum a, Enum b) => Cardinality a -> (Either a b -
 eitherFromEnum carda (Left a) = fromEnum a
 eitherFromEnum carda (Right b) = fromEnum b + runCardinality carda
 
-eitherCardinality :: forall a b. (Enum a, Enum b) => Cardinality a -> Cardinality b -> Cardinality (Either a b)
+eitherCardinality :: forall a b. (Finite a, Finite b) => Cardinality a -> Cardinality b -> Cardinality (Either a b)
 eitherCardinality l r = Cardinality $ (runCardinality l) + (runCardinality r)

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -221,7 +221,6 @@ tupleFromEnum cardb (Tuple a b) = (fromEnum a) * runCardinality cardb + fromEnum
 tupleCardinality :: forall a b. (Enum a, Enum b) => Cardinality a -> Cardinality b -> Cardinality (Tuple a b)
 tupleCardinality l r = Cardinality $ (runCardinality l) * (runCardinality r)
 
--- TODO JB why do both a and b have to be BoundedEnum?
 instance enumEither :: (BoundedEnum a, BoundedEnum b) => Enum (Either a b) where
   succ (Left a) = maybe (Just $ Right bottom) (Just <<< Left) (succ a)
   succ (Right b) = maybe (Nothing) (Just <<< Right) (succ b)

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -64,7 +64,6 @@ enumFromTo from to = unfoldr (\x -> succ x >>= \x' -> if x <= to then pure $ Tup
 -- | `[a,b..c]`
 -- |
 -- | Correctness for using `fromJust` is the same as for `enumFromTo`.
--- TODO this shouldn't require BoundedEnum, just Enum
 enumFromThenTo :: forall a. (BoundedEnum a) => a -> a -> a -> Array a
 enumFromThenTo a b c = (toEnum >>> fromJust) <$> intStepFromTo (b' - a') a' c'
   where a' = fromEnum a


### PR DESCRIPTION
I went back and forth a bit on if to/fromEnum should be in Finite, but I think it makes sense in Enum and make the code nicer.

I found a couple of bugs in the Maybe instance and threw in a Unit instance.

A neat little detail was for the Tuple instance one of the sides had to be Finite, but I could leave the other Enum for the Enum instance :).

For the Maybe instance I had to require Finite on "a" for the Enum instance, but really all it needs is bottom, made me think it might be interesting to split Bounded up or something, but maybe that's taking it too far.

If this is on the right track I'd like to make it work for Listy things, but I realized I think I can make it more general, but I'm not entirely sure how, maybe using Traversable/Foldable/Unfoldable? I don't have much experience w/ those classes.