### PR TITLE
Fix laws

### DIFF
--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -159,8 +159,8 @@ downFrom = unfoldr (map diag <<< pred)
 -- | - ```pred top    >>= pred >>= pred ... pred [cardinality - 1 times] == bottom```
 -- | - ```forall a > bottom: pred a >>= succ == Just a```
 -- | - ```forall a < top:  succ a >>= pred == Just a```
--- | - ```forall a > bottom: fromEnum <$> pred a = Just (fromEnum a - 1)```
--- | - ```forall a < top:  fromEnum <$> succ a = Just (fromEnum a + 1)```
+-- | - ```forall a > bottom: fromEnum <$> pred a = pred (fromEnum a)```
+-- | - ```forall a < top:  fromEnum <$> succ a = succ (fromEnum a)```
 -- | - ```e1 `compare` e2 == fromEnum e1 `compare` fromEnum e2```
 -- | - ```toEnum (fromEnum a) = Just a```
 class (Bounded a, Enum a) <= BoundedEnum a where

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -39,10 +39,10 @@ derive newtype instance ordCardinality :: Ord (Cardinality a)
 -- | Type class for enumerations.
 -- |
 -- | Laws:
--- | - `succ a > pred a`
--- | - `pred a < succ a`
--- | - `pred >=> succ >=> pred = pred`
--- | - `succ >=> pred >=> succ = succ`
+-- | - `succ a > pred a where succ a /= Nothing`
+-- | - `pred a < succ a where succ a /= Nothing`
+-- | - `pred >=> succ >=> pred = pred where succ a /= Nothing`
+-- | - `succ >=> pred >=> succ = succ where succ a /= Nothing`
 class Ord a <= Enum a where
   succ :: a -> Maybe a
   pred :: a -> Maybe a

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -39,12 +39,22 @@ derive newtype instance ordCardinality :: Ord (Cardinality a)
 -- | Type class for enumerations.
 -- |
 -- | Laws:
--- | - Successor: `maybe true (a < _) (succ a)`
--- | - Predecessor: `maybe true (_ < a) (pred a)`
--- | - Succ retracts pred: `pred a >>= succ >>= pred = pred a`
--- | - Pred retracts succ: `succ a >>= pred >>= succ = succ a`
--- | - Non-skipping succ: `b <= a || maybe false (_ <= b) (succ a)`
--- | - Non-skipping pred: `a <= b || maybe false (b <= _) (pred a)`
+-- | - Successor: `all (a < _) (succ a)`
+-- | - Predecessor: `all (_ < a) (pred a)`
+-- | - Succ retracts pred: `pred >=> succ >=> pred = pred`
+-- | - Pred retracts succ: `succ >=> pred >=> succ = succ`
+-- | - Non-skipping succ: `b <= a || any (_ <= b) (succ a)`
+-- | - Non-skipping pred: `a <= b || any (b <= _) (pred a)`
+-- |
+-- | The retraction laws can intuitively be understood as saying that `succ` is
+-- | the opposite of `pred`; if you apply `succ` and then `pred` to something,
+-- | you should end up with what you started with (although of course this
+-- | doesn't apply if you tried to `succ` the last value in an enumeration and
+-- | therefore got `Nothing` out). The non-skipping laws can intuitively be
+-- | understood as saying that `succ` shouldn't skip over any elements of your
+-- | type. For example, without the non-skipping laws, it would be permissible
+-- | to write an `Enum Int` instance where `succ x = Just (x+2)`, and similarly
+-- | `pred x = Just (x-2)`.
 class Ord a <= Enum a where
   succ :: a -> Maybe a
   pred :: a -> Maybe a

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -39,10 +39,12 @@ derive newtype instance ordCardinality :: Ord (Cardinality a)
 -- | Type class for enumerations.
 -- |
 -- | Laws:
--- | - `succ a > pred a where succ a /= Nothing`
--- | - `pred a < succ a where succ a /= Nothing`
--- | - `pred >=> succ >=> pred = pred where succ a /= Nothing`
--- | - `succ >=> pred >=> succ = succ where succ a /= Nothing`
+-- | - Successor: `maybe true (a < _) (succ a)`
+-- | - Predecessor: `maybe true (_ < a) (pred a)`
+-- | - Succ retracts pred: `pred a >>= succ >>= pred = pred a`
+-- | - Pred retracts succ: `succ a >>= pred >>= succ = succ a`
+-- | - Non-skipping succ: `y <= x || maybe false (_ <= y) (succ x)`
+-- | - Non-skipping pred: `x <= y || maybe false (y <= _) (pred x)`
 class Ord a <= Enum a where
   succ :: a -> Maybe a
   pred :: a -> Maybe a

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -43,8 +43,8 @@ derive newtype instance ordCardinality :: Ord (Cardinality a)
 -- | - Predecessor: `maybe true (_ < a) (pred a)`
 -- | - Succ retracts pred: `pred a >>= succ >>= pred = pred a`
 -- | - Pred retracts succ: `succ a >>= pred >>= succ = succ a`
--- | - Non-skipping succ: `y <= x || maybe false (_ <= y) (succ x)`
--- | - Non-skipping pred: `x <= y || maybe false (y <= _) (pred x)`
+-- | - Non-skipping succ: `b <= a || maybe false (_ <= b) (succ a)`
+-- | - Non-skipping pred: `a <= b || maybe false (b <= _) (pred a)`
 class Ord a <= Enum a where
   succ :: a -> Maybe a
   pred :: a -> Maybe a


### PR DESCRIPTION
This PR includes #23 plus the following changes:

- uses `any` and `all` in the laws, as @paf31 suggested
- adds a brief explanation of the less intuitive laws

I think this is now good to go, all the discussion points which were raised in #23 have been addressed.