### PR TITLE
Add roles declarations to forbid unsafe coercions

### DIFF
--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -162,6 +162,8 @@ toEnumWithDefaults low high x = case toEnum x of
 -- | A type for the size of finite enumerations.
 newtype Cardinality a = Cardinality Int
 
+type role Cardinality representational
+
 derive instance newtypeCardinality :: Newtype (Cardinality a) _
 derive newtype instance eqCardinality :: Eq (Cardinality a)
 derive newtype instance ordCardinality :: Ord (Cardinality a)


### PR DESCRIPTION
This prevent terms of type `Cardinality a` to be coerced to type `Cardinality b`, unless `Coercible a b` holds. The reasoning being that types with the same representation should have the same cardinality but two arbitrary types may not.