### PR TITLE
Use Char's top/bottom, not Int's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Fix `Char`'s `toEnum` implementation (#55 by @JordanMartinez)
 
 Other improvements:
 

--- a/src/Data/Enum.purs
+++ b/src/Data/Enum.purs
@@ -314,7 +314,7 @@ diag :: forall a. a -> Tuple a a
 diag a = Tuple a a
 
 charToEnum :: Int -> Maybe Char
-charToEnum n | n >= bottom && n <= top = Just (fromCharCode n)
+charToEnum n | n >= toCharCode bottom && n <= toCharCode top = Just (fromCharCode n)
 charToEnum _ = Nothing
 
 foreign import toCharCode :: Char -> Int

--- a/test/Test/Data/Enum.purs
+++ b/test/Test/Data/Enum.purs
@@ -2,7 +2,7 @@ module Test.Data.Enum (testEnum) where
 
 import Prelude
 
-import Data.Enum (class BoundedEnum, class Enum, Cardinality, defaultCardinality, defaultFromEnum, defaultToEnum, downFrom, downFromIncluding, enumFromThenTo, enumFromTo, upFrom, upFromIncluding)
+import Data.Enum (class BoundedEnum, class Enum, Cardinality, defaultCardinality, defaultFromEnum, defaultToEnum, downFrom, downFromIncluding, enumFromThenTo, enumFromTo, fromEnum, toEnum, upFrom, upFromIncluding)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (unwrap)
 import Data.NonEmpty ((:|))
@@ -193,4 +193,16 @@ testEnum = do
   assertEqual
     { actual: defaultFromEnum (Upto100k 100000)
     , expected: 100000
+    }
+  
+  log "charToEnum"
+  assertEqual
+    { actual: Nothing :: Maybe Char
+    , expected: toEnum (top :: Int)
+    }
+
+  log "charToEnum"
+  assertEqual
+    { actual: Just 'a'
+    , expected: toEnum (fromEnum 'a')
     }


### PR DESCRIPTION
**Description of the change**

Fixes #50. I came across this bug again today, which was introduced in #14:
- Before: https://github.com/purescript/purescript-enums/pull/14/files#diff-8af3ddb5cc6aaf38d6c7f6f0d57dc966f45616b350e635aa006e878c6190b318L151
- After: https://github.com/purescript/purescript-enums/pull/14/files#diff-8af3ddb5cc6aaf38d6c7f6f0d57dc966f45616b350e635aa006e878c6190b318R57

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
